### PR TITLE
카카오 로그인 앱 서버 연동

### DIFF
--- a/app/src/main/java/ddd/buyornot/LoginActivity.kt
+++ b/app/src/main/java/ddd/buyornot/LoginActivity.kt
@@ -1,0 +1,55 @@
+package ddd.buyornot
+
+import android.os.Bundle
+import android.os.PersistableBundle
+import android.util.Log
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.IconButton
+import androidx.compose.ui.Modifier
+import com.ddd.component.BDSImage
+import com.ddd.component.theme.BuyOrNotTheme
+import com.kakao.sdk.user.UserApiClient
+import dagger.hilt.android.AndroidEntryPoint
+import ddd.buyornot.data.service.LoginService
+import ddd.buyornot.login.KakaoLogin
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@AndroidEntryPoint
+class LoginActivity : ComponentActivity() {
+
+    @Inject
+    lateinit var loginService: LoginService
+
+    override fun onCreate(savedInstanceState: Bundle?, persistentState: PersistableBundle?) {
+        super.onCreate(savedInstanceState, persistentState)
+
+        val TAG = "KakaoLogin"
+
+        setContent {
+            BuyOrNotTheme {
+                val kakaoLogin = KakaoLogin(baseContext) { token ->
+                    CoroutineScope(Dispatchers.IO).launch {
+                        loginService.postKakaoAuth(LoginService.KaKaoAuthRequest(token))
+                    }
+                }
+
+                IconButton(
+                    modifier = Modifier.fillMaxWidth(),
+                    onClick = {
+                        kakaoLogin.kakaoLogin()
+                    }
+                ) {
+                    BDSImage(
+                        modifier = Modifier.fillMaxWidth(),
+                        resId = R.drawable.kakao_login_medium_wide
+                    )
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/ddd/buyornot/LoginActivity.kt
+++ b/app/src/main/java/ddd/buyornot/LoginActivity.kt
@@ -2,7 +2,6 @@ package ddd.buyornot
 
 import android.os.Bundle
 import android.os.PersistableBundle
-import android.util.Log
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -10,7 +9,6 @@ import androidx.compose.material3.IconButton
 import androidx.compose.ui.Modifier
 import com.ddd.component.BDSImage
 import com.ddd.component.theme.BuyOrNotTheme
-import com.kakao.sdk.user.UserApiClient
 import dagger.hilt.android.AndroidEntryPoint
 import ddd.buyornot.data.service.LoginService
 import ddd.buyornot.login.KakaoLogin

--- a/app/src/main/java/ddd/buyornot/LoginActivity.kt
+++ b/app/src/main/java/ddd/buyornot/LoginActivity.kt
@@ -26,8 +26,6 @@ class LoginActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?, persistentState: PersistableBundle?) {
         super.onCreate(savedInstanceState, persistentState)
 
-        val TAG = "KakaoLogin"
-
         setContent {
             BuyOrNotTheme {
                 val kakaoLogin = KakaoLogin(baseContext) { token ->

--- a/app/src/main/java/ddd/buyornot/MainActivity.kt
+++ b/app/src/main/java/ddd/buyornot/MainActivity.kt
@@ -10,7 +10,6 @@ import com.ddd.component.BDSImage
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import com.ddd.component.BDSBottomNavigation
 import com.ddd.component.theme.BuyOrNotTheme
-import ddd.buyornot.login.KakaoLogin
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -19,10 +18,9 @@ class MainActivity : ComponentActivity() {
 
         setContent {
             BuyOrNotTheme {
-                val kakaoLogin = KakaoLogin(baseContext)
                 IconButton(
                     modifier = Modifier.fillMaxWidth(),
-                    onClick = { kakaoLogin.kakaoLogin() }
+                    onClick = { }
                 ) {
                     BDSImage(
                         modifier = Modifier.fillMaxWidth(),

--- a/app/src/main/java/ddd/buyornot/login/KakaoLogin.kt
+++ b/app/src/main/java/ddd/buyornot/login/KakaoLogin.kt
@@ -7,10 +7,35 @@ import com.kakao.sdk.common.model.ClientError
 import com.kakao.sdk.common.model.ClientErrorCause
 import com.kakao.sdk.user.UserApiClient
 
-class KakaoLogin(private val context: Context) {
+class KakaoLogin(private val context: Context, private val postAuth: (String) -> Unit) {
     val TAG = "KakaoLogin"
 
-    private val callback: (OAuthToken?, Throwable?) -> Unit = { token, error ->
+    fun kakaoLogin() {
+        // 카카오톡이 설치되어 있으면 카카오톡으로 로그인, 아니면 카카오계정으로 로그인
+        if (UserApiClient.instance.isKakaoTalkLoginAvailable(context)) {
+            UserApiClient.instance.loginWithKakaoTalk(context) { token, error ->
+                if (error != null) {
+                    Log.e(TAG, "카카오톡으로 로그인 실패", error)
+
+                    // 사용자가 카카오톡 설치 후 디바이스 권한 요청 화면에서 로그인을 취소한 경우,
+                    // 의도적인 로그인 취소로 보고 카카오계정으로 로그인 시도 없이 로그인 취소로 처리 (예: 뒤로 가기)
+                    if (error is ClientError && error.reason == ClientErrorCause.Cancelled) {
+                        return@loginWithKakaoTalk
+                    }
+
+                    // 카카오톡에 연결된 카카오계정이 없는 경우, 카카오계정으로 로그인 시도
+                    UserApiClient.instance.loginWithKakaoAccount(context, callback = this::kakaoSignUp)
+                } else if (token != null) {
+                    Log.i(TAG, "카카오톡으로 로그인 성공 ${token.accessToken}")
+                    postAuth.invoke(token.accessToken)
+                }
+            }
+        } else {
+            UserApiClient.instance.loginWithKakaoAccount(context, callback = this::kakaoSignUp)
+        }
+    }
+
+    private fun kakaoSignUp(token: OAuthToken?, error: Throwable?) {
         if (error != null) {
             Log.e(TAG, "카카오계정으로 로그인 실패", error)
         } else if (token != null) {
@@ -57,31 +82,8 @@ class KakaoLogin(private val context: Context) {
                     }
                 }
                 Log.i(TAG, "카카오계정으로 로그인 성공 ${token.accessToken}")
+                postAuth.invoke(token.accessToken)
             }
-        }
-    }
-
-    fun kakaoLogin() {
-        // 카카오톡이 설치되어 있으면 카카오톡으로 로그인, 아니면 카카오계정으로 로그인
-        if (UserApiClient.instance.isKakaoTalkLoginAvailable(context)) {
-            UserApiClient.instance.loginWithKakaoTalk(context) { token, error ->
-                if (error != null) {
-                    Log.e(TAG, "카카오톡으로 로그인 실패", error)
-
-                    // 사용자가 카카오톡 설치 후 디바이스 권한 요청 화면에서 로그인을 취소한 경우,
-                    // 의도적인 로그인 취소로 보고 카카오계정으로 로그인 시도 없이 로그인 취소로 처리 (예: 뒤로 가기)
-                    if (error is ClientError && error.reason == ClientErrorCause.Cancelled) {
-                        return@loginWithKakaoTalk
-                    }
-
-                    // 카카오톡에 연결된 카카오계정이 없는 경우, 카카오계정으로 로그인 시도
-                    UserApiClient.instance.loginWithKakaoAccount(context, callback = callback)
-                } else if (token != null) {
-                    Log.i(TAG, "카카오톡으로 로그인 성공 ${token.accessToken}")
-                }
-            }
-        } else {
-            UserApiClient.instance.loginWithKakaoAccount(context, callback = callback)
         }
     }
 }


### PR DESCRIPTION
카카오 로그인 성공 시 api로 토큰 전송하는 기능 짰습니다.

임시 기능이라 코드가 좀 더러운데 제 최선이었습니다...

서버와 앱 카카오 로그인 연동은 다음과 같습니다.

1. 앱에서 로그인 시도
2. 로그인 성공하면 서버로 토큰 전송 (POST)
3. 서버에서 가입 식별
4. 식별 성공 후 jwt 반환
5. jwt를 앱에 저장 후 유저 정보 필요시 활용

