### PR TITLE
BDSBottomSheetHeader content 정렬 방법 변경

### DIFF
--- a/component-demo/src/main/java/com/ddd/component/demo/DemoHomeActivity.kt
+++ b/component-demo/src/main/java/com/ddd/component/demo/DemoHomeActivity.kt
@@ -5,16 +5,21 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -37,6 +42,7 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight.Companion.SemiBold
 import androidx.compose.ui.unit.dp
@@ -47,8 +53,10 @@ import com.ddd.component.BDSAlertDialog
 import com.ddd.component.BDSBottomSheet
 import com.ddd.component.BDSBottomSheetHeader
 import com.ddd.component.BDSBottomSheetHorizontalDualButton
+import com.ddd.component.BDSBottomSheetVerticalDualButton
 import com.ddd.component.BDSButton
 import com.ddd.component.BDSIconSnackbar
+import com.ddd.component.BDSImage
 import com.ddd.component.BDSPostCard
 import com.ddd.component.BDSText
 import com.ddd.component.PostItem
@@ -242,7 +250,10 @@ fun DemoHomeScreen(
                 onDismissRequest = { openDialog = false },
                 sheetState = bottomSheetState
             )*/
-            DemoBottomSheet(
+            /*DemoBottomSheet(
+                onDismissRequest = { openDialog = false }
+            )*/
+            BottomSheetPostDone(
                 onDismissRequest = { openDialog = false }
             )
         }
@@ -276,7 +287,6 @@ fun DemoDialog(
 }
 
 @Composable
-@ExperimentalMaterial3Api
 fun DemoBottomSheet(
     onDismissRequest: () -> Unit
 ) {
@@ -387,6 +397,62 @@ fun DemoBottomSheet(
         },
         bottomContent = {
             BDSBottomSheetHorizontalDualButton(
+                confirmButton = {
+                    BDSButton {
+
+                    }
+                },
+                cancelButton = {
+                    BDSButton {
+
+                    }
+                }
+            )
+        }
+    )
+}
+
+@Composable
+fun BottomSheetPostDone(
+    onDismissRequest: () -> Unit
+) {
+    BDSBottomSheet(
+        onDismissRequest = onDismissRequest,
+        headerContent = {
+            BDSBottomSheetHeader(
+                center = {
+                    BDSText(text = "투표를 완성했어요!")
+                }
+            )
+        },
+        bodyContent = {
+            Box(modifier = Modifier.fillMaxWidth()) {
+                Box(
+                    modifier = Modifier.size(width = 138.dp, height = 125.dp)
+                        .align(Alignment.Center),
+                    contentAlignment = Alignment.Center
+                ) {
+                    BDSImage(
+                        url = "https://images.unsplash.com/photo-1661956600655-e772b2b97db4?ixlib=rb-4.0.3&ixid=M3wxMjA3fDF8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=870&q=80",
+                        modifier = Modifier
+                            .size(91.dp, 91.dp)
+                            .clip(RoundedCornerShape(8.dp))
+                            .border(width = 1.dp, color = SlateGray900)
+                            .align(Alignment.TopStart)
+                    )
+                    BDSImage(
+                        url = "https://images.unsplash.com/photo-1661956600655-e772b2b97db4?ixlib=rb-4.0.3&ixid=M3wxMjA3fDF8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=870&q=80",
+                        modifier = Modifier
+                            .size(91.dp, 91.dp)
+                            .clip(RoundedCornerShape(8.dp))
+                            .border(width = 1.dp, color = SlateGray900)
+                            .align(Alignment.BottomEnd)
+                    )
+                }
+            }
+        },
+        bottomContent = {
+            BDSBottomSheetVerticalDualButton(
                 confirmButton = {
                     BDSButton {
 

--- a/component/src/main/kotlin/com/ddd/component/BDSBottomSheet.kt
+++ b/component/src/main/kotlin/com/ddd/component/BDSBottomSheet.kt
@@ -154,16 +154,42 @@ fun BDSBottomSheetHeader(
     right: @Composable (() -> Unit)? = null,
     center: @Composable (() -> Unit)? = null
 ) {
-    Row(
+    Box(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(top = 14.dp, bottom = 12.dp, start = 16.dp, end = 16.dp),
+            .padding(top = 14.dp, bottom = 12.dp, start = 16.dp, end = 16.dp)
+    ) {
+        Box(
+            modifier = Modifier.align(Alignment.CenterStart),
+            contentAlignment = Alignment.CenterStart
+        ) {
+            left?.invoke()
+        }
+
+        Box(
+            modifier = Modifier.align(Alignment.Center),
+            contentAlignment = Alignment.Center
+        ) {
+            center?.invoke()
+        }
+
+        Box(
+            modifier = Modifier.align(Alignment.CenterEnd),
+            contentAlignment = Alignment.CenterEnd
+        ) {
+            right?.invoke()
+        }
+    }
+    /*Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            ,
         horizontalArrangement = Arrangement.SpaceBetween
     ) {
         left?.invoke()
         center?.invoke()
         right?.invoke()
-    }
+    }*/
 }
 
 @Composable


### PR DESCRIPTION
기존 BDSBottomSheet에서 content가 비어있는 경우 정렬이 깨져서 수정했습니다.

BDSAppbar랑 동일하게 처리했습니다.

PostList/Done 바텀 시트 작업했습니다.